### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   tagged-release:
 
+    permissions:
+      contents: write
     runs-on:
       ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/dplocki/pesel-generator/security/code-scanning/2](https://github.com/dplocki/pesel-generator/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow to restrict the `GITHUB_TOKEN` permissions to the minimum required. Since the workflow creates releases and uploads assets, it needs `contents: write` permission for the `marvinpinto/action-automatic-releases` step. If other jobs or steps only require read access, we can set the default at the workflow level to `contents: read` and override it for the job that needs write access. However, since there is only one job, the simplest and clearest fix is to add a `permissions` block at the job level for `tagged-release` with `contents: write`. This should be added just above `runs-on:` in the job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
