### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Run Unit Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/dplocki/pesel-generator/security/code-scanning/1](https://github.com/dplocki/pesel-generator/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. Since this workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just below the `name` and before the `on` block. This will apply the minimal required permissions to all jobs in the workflow, unless overridden at the job level. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
